### PR TITLE
FIx in CMakeLists.txt & FindCameraMatrices.h

### DIFF
--- a/SfMToyLib/CMakeLists.txt
+++ b/SfMToyLib/CMakeLists.txt
@@ -1,10 +1,12 @@
+cmake_minimum_required(VERSION 2.6)
+
 if(EIGEN_INCLUDE_DIRS) # if compiling with PCL, it will bring Eigen with it
 	message(STATUS "SfMToyLib will use Eigen")
 	include_directories(${EIGEN_INCLUDE_DIRS})
 	add_definitions( -DUSE_EIGEN )
 endif()
 
-set(SSBA_LIBRARY_DIR "${CMAKE_SOURCE_DIR}/3rdparty/SSBA-3.0/build" CACHE PATH "Directory to find SSBA libs")
+set(SSBA_LIBRARY_DIR "${CMAKE_SOURCE_DIR}/../3rdparty/SSBA-3.0/build" CACHE PATH "Directory to find SSBA libs")
 
 link_directories(
 	${SSBA_LIBRARY_DIR}

--- a/SfMToyLib/FindCameraMatrices.h
+++ b/SfMToyLib/FindCameraMatrices.h
@@ -22,8 +22,10 @@ cv::Mat GetFundamentalMat(	const std::vector<cv::KeyPoint>& imgpts1,
 							const std::vector<cv::KeyPoint>& imgpts2,
 							std::vector<cv::KeyPoint>& imgpts1_good,
 							std::vector<cv::KeyPoint>& imgpts2_good,
-							std::vector<cv::DMatch>& matches,
-							const cv::Mat& = cv::Mat(), const cv::Mat& = cv::Mat()
+							std::vector<cv::DMatch>& matches
+#ifdef __SFM__DEBUG__
+					  		,const Mat& img_1, const Mat& img_2
+#endif
 						  );
 
 bool FindCameraMatrices(const cv::Mat& K, 


### PR DESCRIPTION
In CMakeLists.txt, SSBA_LIBRARY_DIR wasn't correct.
In FindCameraMatrices.h declaration of "GetFundamentalMat" was different than definition in FindCameraMatrices.cpp
