### PR TITLE
Fix: change colormapping (byte to unsigned byte [0,255])

### DIFF
--- a/sfmviewer.cpp
+++ b/sfmviewer.cpp
@@ -85,7 +85,7 @@ void SFMViewer::draw() {
 	glDisable(GL_LIGHTING);
 	glBegin(GL_POINTS);
 	for (int i = 0; i < m_pcld.size(); ++i) {
-		glColor3b(m_pcldrgb[i][0],m_pcldrgb[i][1],m_pcldrgb[i][2]);
+        glColor3ub(m_pcldrgb[i][0],m_pcldrgb[i][1],m_pcldrgb[i][2]);
 		glVertex3dv(&(m_pcld[i].x));
 	}
 	glEnd();


### PR DESCRIPTION
Changed glColor3b to glColor3ub, which results in correct color mapping to [0,255].
