### PR TITLE
modify IterativeLinearLSTriangulation function

### DIFF
--- a/SfMToyLib/Triangulation.cpp
+++ b/SfMToyLib/Triangulation.cpp
@@ -90,21 +90,8 @@ Mat_<double> IterativeLinearLSTriangulation(Point3d u,	//homogenous image point 
 											Matx34d P1			//camera 2 matrix
 											) {
 	double wi = 1, wi1 = 1;
-	Mat_<double> X(4,1); 
+	Mat_<double> X(4,1), X_(4,1);
 	for (int i=0; i<10; i++) { //Hartley suggests 10 iterations at most
-		Mat_<double> X_ = LinearLSTriangulation(u,P,u1,P1);
-		X(0) = X_(0); X(1) = X_(1); X(2) = X_(2); X(3) = 1.0;
-		
-		//recalculate weights
-		double p2x = Mat_<double>(Mat_<double>(P).row(2)*X)(0);
-		double p2x1 = Mat_<double>(Mat_<double>(P1).row(2)*X)(0);
-		
-		//breaking point
-		if(fabsf(wi - p2x) <= EPSILON && fabsf(wi1 - p2x1) <= EPSILON) break;
-		
-		wi = p2x;
-		wi1 = p2x1;
-		
 		//reweight equations and solve
 		Matx43d A((u.x*P(2,0)-P(0,0))/wi,		(u.x*P(2,1)-P(0,1))/wi,			(u.x*P(2,2)-P(0,2))/wi,		
 				  (u.y*P(2,0)-P(1,0))/wi,		(u.y*P(2,1)-P(1,1))/wi,			(u.y*P(2,2)-P(1,2))/wi,		
@@ -119,6 +106,17 @@ Mat_<double> IterativeLinearLSTriangulation(Point3d u,	//homogenous image point 
 		
 		solve(A,B,X_,DECOMP_SVD);
 		X(0) = X_(0); X(1) = X_(1); X(2) = X_(2); X(3) = 1.0;
+
+		//recalculate weights
+		double p2x = Mat_<double>(Mat_<double>(P).row(2)*X)(0);
+		double p2x1 = Mat_<double>(Mat_<double>(P1).row(2)*X)(0);
+		
+		//breaking point
+		if(fabsf(wi - p2x) <= EPSILON && fabsf(wi1 - p2x1) <= EPSILON) break;
+		
+		wi = p2x;
+		wi1 = p2x1;
+		
 	}
 	return X;
 }


### PR DESCRIPTION
modify IterativeLinearLSTriangulation function according 'Triangulation',  Hartley, R.I. and Sturm, P., Computer vision and image understanding, 1997

when the first loop, you get p2x and p2x1, but when the second loop, you get the same p2x and p2x1, so the loop will always exit when i=1.