### PR TITLE
canonical way to find libqglviewer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,3 +139,7 @@ target_link_libraries(SfMToyUI
 	${OPENGL_LIBRARIES}
 	)
 
+if(APPLE)
+	add_custom_command(TARGET SfMToyUI POST_BUILD COMMAND install_name_tool -change QGLViewer.framework/Versions/2/QGLViewer ${QGLVIEWER_DIR_HINT}/QGLViewer.framework/Versions/2/QGLViewer ./SfMToyUI )
+endif()
+


### PR DESCRIPTION
I've had problems finding libqglviewer on mac, installed with brew on os x yosemite.
While this commit does not fix the problem, it's a more canonical way of finding the library. I found this code here:

https://github.com/RainerKuemmerle/g2o/blob/master/cmake_modules/FindQGLViewer.cmake

Here's a file list, which might help:

$ find /usr/local | grep qglviewer
/usr/local/Cellar/libqglviewer
/usr/local/Cellar/libqglviewer/2.5.1
/usr/local/Cellar/libqglviewer/2.5.1/CHANGELOG
/usr/local/Cellar/libqglviewer/2.5.1/INSTALL_RECEIPT.json
/usr/local/Cellar/libqglviewer/2.5.1/LICENCE
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Contents
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Contents/Info.plist
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Headers
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/QGLViewer
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/QGLViewer.prl
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/camera.h
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/config.h
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/constraint.h
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/domUtils.h
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/frame.h
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/keyFrameInterpolator.h
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/manipulatedCameraFrame.h
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/manipulatedFrame.h
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/mouseGrabber.h
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/QGLViewer
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/qglviewer.h
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/qglviewer.icns
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/qglviewer_fr.qm
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/quaternion.h
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/Headers/vec.h
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/2/QGLViewer
/usr/local/Cellar/libqglviewer/2.5.1/QGLViewer.framework/Versions/Current
/usr/local/Cellar/libqglviewer/2.5.1/README
/usr/local/Library/Formula/libqglviewer.rb
/usr/local/Library/LinkedKegs/libqglviewer
/usr/local/opt/libqglviewer
