### PR TITLE
add missing qt requirement: QtCore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ ENDIF(USE_GUI)
 
 IF(USE_QT)
 	########## Qt stuff ##########
-	find_package(Qt4 REQUIRED QtGui QtOpenGL QtXml)
+	find_package(Qt4 REQUIRED QtGui QtOpenGL QtXml QtCore)
 	
 	ADD_DEFINITIONS(${QT_DEFINITIONS})
 	include_directories(${QT_INCLUDES})


### PR DESCRIPTION
I wasn't able to compile the project until I added the missing dependency.

System details:

OS X Yosemite (10.10.5 (14F27))

$ brew info qt
qt: stable 4.8.7 (bottled), HEAD
Cross-platform application and UI framework
https://www.qt.io/
/usr/local/Cellar/qt/4.8.7 (2794 files, 122M) *

$ brew info libqglviewer
libqglviewer: stable 2.6.1 (bottled), HEAD
C++ Qt library to create OpenGL 3D viewers
http://www.libqglviewer.com/
/usr/local/Cellar/libqglviewer/2.6.1 (21 files, 1.1M) *
  Poured from bottle
