### PR TITLE
Some CMake cleanup, Fix compile with gcc 5 and Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 #  SOFTWARE.
 
 project(SfMToyExample)
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.2)
 
 #set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
@@ -30,10 +30,9 @@ find_package(Boost      REQUIRED COMPONENTS system chrono filesystem unit_test_f
 find_package(Ceres      REQUIRED)
 find_package(OpenGL)
 
-if (NOT APPLE)
-else() 
-    add_definitions("-std=gnu++11")
-endif()
+# enable C++11 standard
+set(CXX_STANDARD 11)
+set(CXX_STANDARD_REQUIRED ON)
 
 include_directories(${Boost_INCLUDE_DIR})
 link_directories   (${Boost_LIBRARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(Ceres      REQUIRED)
 find_package(OpenGL)
 
 # enable C++11 standard
-set(CXX_STANDARD 11)
+set(CXX_STANDARD          11)
 set(CXX_STANDARD_REQUIRED ON)
 
 include_directories(${Boost_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ find_package(Ceres      REQUIRED)
 find_package(OpenGL)
 
 if (NOT APPLE)
-    find_package(OpenMP)
 else() 
     add_definitions("-std=gnu++11")
 endif()
@@ -49,12 +48,6 @@ IF(APPLE)
 ENDIF(APPLE)
 
 set( CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -D__SFM__DEBUG__" )
-
-if(OPENMP_FOUND)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS} -DHAVE_OPENMP")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS} -DHAVE_OPENMP")
-	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-endif()
 
 include_directories(SfMToyLib)
 

--- a/SfMToyLib/SfM.cpp
+++ b/SfMToyLib/SfM.cpp
@@ -32,6 +32,7 @@
 #include <iostream>
 #include <algorithm>
 #include <thread>
+#include <mutex>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/calib3d/calib3d.hpp>

--- a/SfMToyLib/SfMBundleAdjustmentUtils.cpp
+++ b/SfMToyLib/SfMBundleAdjustmentUtils.cpp
@@ -30,6 +30,8 @@
 #include <ceres/ceres.h>
 #include <ceres/rotation.h>
 
+#include <mutex>
+
 using namespace cv;
 using namespace std;
 


### PR DESCRIPTION
I did the following changes:
- removed OpenMP from the CMake scripts, as the support is not required any more
- enabled C++11 for all platforms and compilers as it is required anyway
- added some missing <mutex> includes which are required for gcc/linux