### PR TITLE
Added missing CMAKE_ prefixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ find_package(Ceres      REQUIRED)
 find_package(OpenGL)
 
 # enable C++11 standard
-set(CXX_STANDARD          11)
-set(CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD          11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include_directories(${Boost_INCLUDE_DIR})
 link_directories   (${Boost_LIBRARY_DIR})


### PR DESCRIPTION
Added missing CMAKE_ prefixes for 

CXX_STANDARD
CXX_STANDARD_REQUIRED

as the library did not compile on Ubuntu 14.04 without this.