### PR TITLE
fix missing fstream include

### DIFF
--- a/SfMToyLib/SfM.cpp
+++ b/SfMToyLib/SfM.cpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <thread>
 #include <mutex>
+#include <fstream>
 
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/calib3d/calib3d.hpp>


### PR DESCRIPTION
Otherwise there will be compilation error

```
/home/jasjuang/SfM-Toy-Library/SfMToyLib/SfM.cpp:636:18: error: variable ‘std::ofstream ofs’ has initializer but incomplete type
     ofstream ofs(prefix + "_points.ply");
                  ^
/home/jasjuang/SfM-Toy-Library/SfMToyLib/SfM.cpp:668:19: error: variable ‘std::ofstream ofsc’ has initializer but incomplete type
     ofstream ofsc(prefix + "_cameras.ply");
```